### PR TITLE
Update recommended settings

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ module.exports = {
   },
   configs: {
     recommended: {
+      plugins: ['promise'],
       rules: {
         'promise/always-return': 'error',
         'promise/no-return-wrap': 'error',


### PR DESCRIPTION
Ensure eslint-plugin-promise is loaded when using recommended settings.

**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Other, please explain:

**What changes did you make? (Give an overview)**
When using promise/recommended-config, eslint-plugin-promise wasn't actually including the `plugin` in the configuration, only the `rules`.
